### PR TITLE
fixed calculator bug

### DIFF
--- a/assets/js/calculator.js
+++ b/assets/js/calculator.js
@@ -7,20 +7,23 @@ for (item of buttons) {
         console.log('Button text is ', buttonText);
         if (buttonText == 'X') {
             buttonText = '*';
-            screenValue += buttonText;
-            screen.value = screenValue;
+            screen.value += buttonText;
         }
         else if (buttonText == 'C') {
             screenValue = "";
             screen.value = screenValue;
         }
         else if (buttonText == '=') {
-            screen.value = eval(screenValue);
+            screen.value = eval(screen.value);
         }
         else {
-            screenValue += buttonText;
-            screen.value = screenValue;
+            if (screenValue.length==0) {
+                screenValue += buttonText;
+                screen.value = screenValue;
+            }
+            else {
+                screen.value += buttonText;
+            }
         }
-
     })
 }


### PR DESCRIPTION
## Related Issue
   There was a bug in the calculator , the final value was not displayed rather the whole string was displayed.
Closes: #179 

### Describe the changes you've made
Changed only one file ``assets/js/calculator.js``  and made the necessary changes.

### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
`NA`

### Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] New and existing unit tests pass locally with my changes.

### Screenshots
![image](https://user-images.githubusercontent.com/56315878/109455513-d26fae80-7a7c-11eb-8cfe-099b783bd459.png)
![image](https://user-images.githubusercontent.com/56315878/109455525-e0253400-7a7c-11eb-9b50-0d5a1fb82c73.png)

