### PR TITLE
Fixed issue#189

### DIFF
--- a/assets/css/passwordGenerator.css
+++ b/assets/css/passwordGenerator.css
@@ -34,7 +34,7 @@ body {
     height: 70px;
     width: 100%;
     position: relative;
-    padding: 1rem;
+    padding: 44px;
     overflow: auto;
 }
 
@@ -82,3 +82,46 @@ body {
     margin-top: 1rem;
     width: 100%;
 }
+
+#tooltip{
+    display:none;
+    color:white;
+    padding:20px;
+    background:black;
+    width:180px;
+    height: 100px;
+    border-radius:5px;
+    position:absolute;
+    left:50%;
+    top:11%;
+    transform:translateX(-50%);
+    transform:translateY(-50%);
+    font-size:1rem;  
+    }
+
+#tooltip:before{
+    content:"";
+    position:absolute;
+    width: 0; 
+    height: 0; 
+    border-left: 20px solid transparent;
+    border-right: 20px solid transparent;
+    border-top: 20px solid black;
+    bottom:-19px;
+    left:15%;
+  }
+
+#hide{
+    color:red;
+    position:absolute;
+    top:3%;
+    right:3%;
+    cursor:pointer;
+    text-decoration:none;
+}
+   
+#copy{
+    border-radius: 3px;
+
+}
+

--- a/assets/css/passwordGenerator.css
+++ b/assets/css/passwordGenerator.css
@@ -34,7 +34,8 @@ body {
     height: 70px;
     width: 100%;
     position: relative;
-    padding: 44px;
+    padding-left: 44px;
+    padding-right: 59px;
     overflow: auto;
 }
 

--- a/assets/js/passwordGenerator.js
+++ b/assets/js/passwordGenerator.js
@@ -6,6 +6,7 @@ const lowerEl = document.getElementById("lower");
 const numberEl = document.getElementById("number");
 const symbolEl = document.getElementById("symbol");
 const generateEl = document.getElementById("generate");
+const tooltip = document.getElementById("tooltip");
 
 const upperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const lowerLetters = "abcdefghijklmnopqrstuvwxyz";
@@ -55,6 +56,8 @@ function generatePassword() {
     }
 
     pwEl.innerText = password;
+    copyEl.innerText="Copy";
+    copyEl.style.color="rgb(29, 2, 56)";
 }
 
 function generateX() {
@@ -83,6 +86,9 @@ function generateX() {
 generateEl.addEventListener("click", generatePassword);
 
 copyEl.addEventListener("click", () => {
+    copyEl.innerText="Copied";
+    copyEl.style.color="green";
+
     const textarea = document.createElement("textarea");
     const password = pwEl.innerText;
 
@@ -95,5 +101,12 @@ copyEl.addEventListener("click", () => {
     textarea.select();
     document.execCommand("copy");
     textarea.remove();
-    alert("Password copied to clipboard");
+
 });
+
+function showTooltip(){
+    tooltip.style.display = 'block';
+  }
+function hideTooltip(){
+    tooltip.style.display = 'none';
+}

--- a/public/passwordGenerator.html
+++ b/public/passwordGenerator.html
@@ -4,15 +4,22 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Password Generator</title>
+        <!-- Font Awesome -->
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
+          integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
         <link rel="stylesheet" href="../assets/css/passwordGenerator.css" />
         <script src="../assets/js/passwordGenerator.js" defer></script>
     </head>
     <body>
+      <div id="tooltip"> Password copied to clipboard!! 
+        <a href="#" id="hide" onClick="hideTooltip()"><i class="far fa-times-circle fa-sm"></i></a>
+        </div>
+          </div>
         <div class="pw-container">
             <div class="pw-header">
                 <div class="pw">
                     <span id="pw">l823Zs78#Css09@</span>
-                    <button id="copy">Copy</button>
+                    <button id="copy" onClick="showTooltip()">Copy</button>
                 </div>
             </div>
             <div class="pw-body">
@@ -36,7 +43,7 @@
                     <label for="symbol">Contain Symbols</label>
                     <input id="symbol" type="checkbox" />
                 </div>
-                <button class="generate" id="generate">
+                <button class="generate" id="generate" onClick="hideTooltip()">
                     Generate Password
                 </button>
             </div>


### PR DESCRIPTION
## Related Issue
  - On clicking the copy button, the text `copy` was not changing to `copied`
  - An alert message saying `Password copied to clipboard` appeared
  - Copy button was overlapping with the password generated

Closes: #189 

### Describe the changes you've made
- On clicking the copy button now, the text changes from `copy` to `copied` and even the color of text changes to green
- The alert box has been changed to a tooltip
- Padding has been added to prevent overlapping of copy button and password

### Describe if there is any unusual behaviour of your code
NA

### Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.

### Screenshots
<img width="1060" alt="Screen Shot 2021-03-03 at 12 29 38 AM" src="https://user-images.githubusercontent.com/56118366/109700424-b91f4d00-7bb7-11eb-9c80-ab65a4173739.png">

