### PR TITLE
corrected typo error in local storage display-card

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ let projectData = [
     projectUrl: "public/counter.html",
   },
   {
-    projectName: "Local Storgae",
+    projectName: "Local Storage",
     projectImage: "assets/Images/localstorage.jpeg",
     projectUrl: "public/localstorage.html",
   },


### PR DESCRIPTION
## Related Issue
  - Typo Error in local storage display-card on website

Closes: #291 

### Describe the changes you've made
Earlier it was written on the display-card as "Local Storgae", which I corrected to "Local Storage".
(under GSSOC 2021)

### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

### Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.

### Screenshots
Put any screenshot(s) of the project here.
![Screenshot (647)](https://user-images.githubusercontent.com/78426468/110615613-9d203a80-81b9-11eb-9a63-7348ab214201.png)
