### PR TITLE
Progress-Bar made responsive

### DIFF
--- a/assets/css/progressbar.css
+++ b/assets/css/progressbar.css
@@ -61,7 +61,7 @@ footer{
 }
 
 @media(max-width: 600px){
-    btn-move{
+    .btn-move{
     width: auto;
     padding: 7px 10px;
     text-align: center;
@@ -76,4 +76,43 @@ footer{
     margin: 0 0px;
     width: auto;
 }
+}
+@media only screen and (max-width: 465px) {
+    .progresss{
+        width:380px;
+    }
+}
+@media only screen and (max-width: 405px) {
+    .progresss{
+        width:350px;
+    }
+}
+@media only screen and (max-width: 370px) {
+    .progresss{
+        width:300px;
+    }
+    ul{
+        font-size: 0.2rem;
+    }
+}
+@media only screen and (max-width: 345px) {
+    .progresss{
+        width:290px;
+    }
+    ul{
+        text-align: center;
+    }
+    .btn-html,.btn-css,.btn-js{
+        font-size:0.8rem;
+        margin:10px;
+    }
+    .btn-react,.btn-wordpress{
+        font-size: 0.8rem;
+        margin:20px;
+    }
+}
+@media only screen and (max-width: 290px) {
+    .progresss{
+        width:250px;
+    }
 }


### PR DESCRIPTION
Fixed- #854
Made site responsive

Screenshots
Earlier:

![pb-o](https://user-images.githubusercontent.com/66208607/113733192-dd6ecc00-9717-11eb-9639-bad7410a6a7a.png)

Now:

![pb-n](https://user-images.githubusercontent.com/66208607/113733248-e8c1f780-9717-11eb-8726-a045ec2bf275.png)

@Vishal-raj-1 @urvashi-code1255 @harshgupta20 @991rajat @ridsuteri Please view my PR.