### PR TITLE
Removed overlapping of text and icon - FAQ project

### DIFF
--- a/assets/css/FAQs.css
+++ b/assets/css/FAQs.css
@@ -53,7 +53,6 @@
  .accordion button .icon {
 	 display: inline-block;
 	 position: absolute;
-	 top: 18px;
 	 right: 0;
 	 width: 22px;
 	 height: 22px;


### PR DESCRIPTION
Fixed- #854

Screenshots:
Earlier:

![faq-old](https://user-images.githubusercontent.com/66208607/114313163-037ade80-9b13-11eb-8828-ac9b3b4612fa.png)

NOW:

![faq-new](https://user-images.githubusercontent.com/66208607/114313171-142b5480-9b13-11eb-92d6-f4608b86e07a.png)

@Vishal-raj-1 @urvashi-code1255 @harshgupta20 @991rajat @ridsuteri Please view my PR