### PR TITLE
Word-Scramble made responsive

### DIFF
--- a/assets/css/wordScramble.css
+++ b/assets/css/wordScramble.css
@@ -2,6 +2,7 @@
 margin:0;
 padding:0;
 box-sizing:border-box;
+overflow-x: hidden;
 }
   header{
     width: 100%;
@@ -31,7 +32,7 @@ section{
   align-items: center;
 }
 .gameArea{
-  width: 60%;
+  width: 100%;
   height: 500px;
   padding: 20px 0;
   border-radius: 20px;
@@ -42,6 +43,7 @@ section{
   align-items: center;
   font-family: sans-serif;
   box-shadow: 0 8px 6px -6px black;
+  max-width: 700px;
 }
 .items{
   display: inline-flex;


### PR DESCRIPTION
Fixed- #854
Made site responsive

Screenshots:
Earlier:

![sc-old](https://user-images.githubusercontent.com/66208607/114412579-dc7fe380-9bca-11eb-8aa2-51854330aad4.png)

NOW:

![sc-n1](https://user-images.githubusercontent.com/66208607/114412628-e6a1e200-9bca-11eb-9e3e-abb7703acffe.png)

![sc-n2](https://user-images.githubusercontent.com/66208607/114412635-e86ba580-9bca-11eb-95d0-b2dc8f737f40.png)

@Vishal-raj-1 @urvashi-code1255 @harshgupta20 @ridsuteri Please view my PR