### PR TITLE
pr-labeler added

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,15 @@
+name: Add label to Merged PR
+
+on:
+  pull_request_target:
+    types: [closed]
+
+
+jobs:
+  automate-issues-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labeling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: 'GSSOC21'


### PR DESCRIPTION
## Fixes #1676 

- pr-labeler of GitHub Action Not Present, Adding the pr-labeler using GitHub Action

fix #1676

#### Replacing the .yml file

GitHub Action not Taking the .yml file in GitHub Action Workflow as a result. I will completely change the pr-labeler with the help of taking labeler and pr closed action. The job of this Action will be to add the GSSOC21 label on Merged PR.

## Trial Checking

I have Tried the Code on my Repository, GitHub Bot Adds the GSSOC21 Label Automatically after the PR is merged Successfully. Here is the Screenshot that Shows How the Workflow works!

![Capture](https://user-images.githubusercontent.com/73196470/119857293-0f8af600-bf31-11eb-9253-173567e65abf.JPG)

Closes: #1676 

### Checklist:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.

### Screenshots
![sadf](https://user-images.githubusercontent.com/73196470/119926611-51e61e80-bf95-11eb-89d7-3576d32f2c72.JPG)

