### PR TITLE
Auto Message on closing of pr but it must be only on merging pr

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,6 +6,7 @@ on:
 
 
 jobs:
+  if: github.event.pull_request.merged == true
   automate-issues-labels:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Auto Message on closing of pr but it must be only on merging pr
  - Info about Issue or bug

Closes:  #1716 

### Describe the changes you've made
A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

this will also add a label on merged pr but currently, it is add on the closing of the issue
Currently, when pr is closed we are getting this message also, but this must be there only when pr is merged

### Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
