### PR TITLE
Fixed  sidebar footer issue #1938

### DIFF
--- a/index.css
+++ b/index.css
@@ -9,6 +9,7 @@ body {
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
+  z-index: 1;
 }
 
 .icon-bar a {


### PR DESCRIPTION
## Related Issue
  - sidebar hides below  footer section

Closes: #[1938]

### Describe the changes you've made
Added z-index in css file so that sidenav should be visible whenever someone scrolls till the last in footer section sidenav will be visible properly.

### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

### Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X ] My code follows the style guidelines of this project.
- [X ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X ] New and existing unit tests pass locally with my changes.

### Screenshots
Put any screenshot(s) of the project here.
![SIDENAV](https://user-images.githubusercontent.com/89387408/232020296-1bfb64df-939c-4f06-947a-96572f0ee2bd.png)

